### PR TITLE
Include extraction of LCS

### DIFF
--- a/Dynamic Programming/Longest Common Subsequence.cpp
+++ b/Dynamic Programming/Longest Common Subsequence.cpp
@@ -6,9 +6,6 @@
 
 #include <stdio.h>
 #include <string>
-#include <algorithm>
-#include <iostream>
-
 #define MAX_N 1001
 using namespace std;
 
@@ -48,6 +45,10 @@ inline int LCS()
     return dp[n][m];
 }
 
+// Backtracks through the dynamic programming to reconstruct
+// the subsequence in question rather than just its length
+// For all cases (A[i-1] == B[j-1]) on the backtrack (route == 3)
+// places this character at the end of the string still to be found
 inline char *getLCS() {
     int x = n, y = m;
     int length = dp[n][m];
@@ -67,9 +68,7 @@ inline char *getLCS() {
             return ""; //invalid input
         }
     }
-
-    return seq;
-    
+    return seq;    
 }
 
 int main()


### PR DESCRIPTION
I've added extraction of the longest common subsequence on top of finding its length as an example of keeping track of how the optimal solution is found.

Just an extra matrix with numbers (0 = base case; 1 = from left; 2 = from above; 3 = from above-left) like the lecturer did with arrows.
## 

Dan Ward (dw445)
