### PR TITLE
Fix Splay Tree bugs

### DIFF
--- a/Data Structures/Splay Tree.cpp
+++ b/Data Structures/Splay Tree.cpp
@@ -256,7 +256,7 @@ TreeNode* SplayTree::find(int x)
         }
     }
     if (ret != NULL) splay(ret);
-    else splay(prev);
+    else if (prev != NULL) splay(prev);
     return ret;
 }
 
@@ -319,6 +319,10 @@ TreeNode* subtree_min(TreeNode *subRoot)
 void SplayTree::Delete(int x)
 {
     TreeNode *del = find(x);
+    if (del == NULL)
+    {
+        return;
+    }
     TreeNode *L = del -> left;
     TreeNode *R = del -> right;
     if (L == NULL && R == NULL)


### PR DESCRIPTION
This adds some NULL pointer checks to avoid segfaults that happen when:
- A key to be deleted is not present in the tree
- SplayTree::find is called when the tree is empty