### PR TITLE
Update van Emde Boas Tree.cpp

### DIFF
--- a/Data Structures/van Emde Boas Tree.cpp
+++ b/Data Structures/van Emde Boas Tree.cpp
@@ -193,6 +193,8 @@ void vEB::Delete(llu x)
                 llu nextMinLo = cluster[summary -> min()] -> min();
                 llu nextMin = nextMinHi * subSize + nextMinLo;
                 this -> Delete(nextMin);
+                if ((*M) == (*m))
+                    (*M) = nextMin; 
                 (*m) = nextMin;
             }
         }


### PR DESCRIPTION
the *M must be changed if one element is left in the cluster after line 195
because line 195: this->Delete(nextMin) will also change *M to equal *m if one item is left
this will cause an error where *M is lower than *m because in the next line, *m is changed to the nextMin when *M should also equal nextMin